### PR TITLE
partially fixed issue with footnotes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -51,6 +51,13 @@ export default class PolicyGuide extends Component {
         scrollToTopOfResults()
       }
     })
+    this.pathname = this.props.location.pathname
+  }
+
+  shouldComponentUpdate(nextProps, nextState) {
+    const changed = nextProps.location.pathname !== this.pathname
+    this.pathname = nextProps.location.pathname
+    return changed
   }
 
   onNavChange() {


### PR DESCRIPTION
This PR partially fixes https://github.com/GSA/code-gov-front-end/issues/102.

It does not respect the footnote when loading a page like http://code.gov/policy-guide/objectives#fn19

It does however stop the page from re-rendering whenever the user clicks a footnote reference or footnote, which allows a user to successfully jump to a footnote when they click the reference.  It does this by basically only re-rendering if the pathname (actual page) changes.

I had to set `this.pathame` rather than use the more standard `this.props.location.pathname` because `this.props.location.pathname` is somehow updating before shouldComponentUpdate is triggered.
