### PR TITLE
Footnote fix

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,8 +38,23 @@ const linksForSideNav = pages.map(({display, route}) => {
   }
 })
 
+const scrollToHash = () => {
+  const hash = window.location.hash
+  if (hash) {
+    const id = hash.replace("#","")
+    if (id) {
+      console.log(`scrolling to element with id "${id}"`)
+      document.getElementById(id).scrollIntoView()
+    }
+  }
+}
+
 const PolicyGuidePage = ({ url }) => {
- return <div className="docs-content"><LazyHTML url={url}/></div>
+ return (
+    <div className="docs-content">
+      <LazyHTML url={url} onUpdate={scrollToHash}/>
+    </div>
+  )
 }
 
 export default class PolicyGuide extends Component {

--- a/src/index.js
+++ b/src/index.js
@@ -51,6 +51,13 @@ export default class PolicyGuide extends Component {
         scrollToTopOfResults()
       }
     })
+    this.pathname = this.props.location.pathname
+  }
+
+  shouldComponentUpdate(nextProps, nextState) {
+    const changed = nextProps.location.pathname !== this.pathname
+    this.pathname = nextProps.location.pathname
+    return changed
   }
 
   onNavChange() {


### PR DESCRIPTION
Fixes https://github.com/GSA/code-gov-front-end/issues/102

This PR does a few things:
 - When the user loads a URL with a footnote hash in it like, https://code.gov/policy-guide/introduction#fn4, the page waits for the content to load and then jumps to the footnote
- When a user clicks on a footnote number or on the link to jump back to the footnote reference in the main text, the page jumps to the target anchor tag.  Previously, the page would reload when a user clicks on a footnote number.  The solution was to only re-render the page content if the pathname in the url changes.


Additional Note: I had to set this.pathame rather than use the more standard this.props.location.pathname because this.props.location.pathname is somehow updating before shouldComponentUpdate is triggered.