### PR TITLE
Export PolicyGuidePage

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -49,7 +49,7 @@ const scrollToHash = () => {
   }
 }
 
-const PolicyGuidePage = ({ url }) => {
+export const PolicyGuidePage = ({ url }) => {
  return (
     <div className="docs-content">
       <LazyHTML url={url} onUpdate={scrollToHash}/>


### PR DESCRIPTION
## Why?
- needed to export `PolicyGuidePage` component for testing in the `code-gov-front-end` repo

## What Changed?
- export `PolicyGuidePage` component